### PR TITLE
MsBuild: When building a VS solution always clean out generated files

### DIFF
--- a/src/msbuild/scripts/build.binaries.msbuild
+++ b/src/msbuild/scripts/build.binaries.msbuild
@@ -96,6 +96,7 @@
         
         <MSBuild Projects="$(FileSln)" 
                  Properties="Configuration=$(Configuration);Platform=$(Platform);BuildPropertyFile=$(BuildPropertyFile)" 
+                 Targets="Rebuild"
                  Condition=" '$(ShouldExecute)' == 'true' " />
     </Target>
     


### PR DESCRIPTION
When building a VS solution nBuildKit should always provide the Rebuild target so that any generated files that were generated earlier are remove and re-generated with the current configuration / platform.
