### PR TITLE
Use vstest from the professional folder when enterprise is not installed

### DIFF
--- a/src/nbuildkit/actions/build/build.shared.preuser.props
+++ b/src/nbuildkit/actions/build/build.shared.preuser.props
@@ -232,6 +232,7 @@
         -->
         <ToolsExternalVisualStudioDir Condition=" '$(ToolsExternalVisualStudioDir)' == '' AND Exists('C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools')">C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools</ToolsExternalVisualStudioDir>
         <ToolsExternalVisualStudioDir Condition=" '$(ToolsExternalVisualStudioDir)' == '' AND Exists('C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise')">C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise</ToolsExternalVisualStudioDir>
+        <ToolsExternalVisualStudioDir Condition=" '$(ToolsExternalVisualStudioDir)' == '' AND Exists('C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional')">C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional</ToolsExternalVisualStudioDir>
         <ToolsExternalVisualStudioDir Condition=" '$(ToolsExternalVisualStudioDir)' == '' AND Exists('C:\Program Files (x86)\Microsoft Visual Studio 14.0')">C:\Program Files (x86)\Microsoft Visual Studio 14.0</ToolsExternalVisualStudioDir>
         <ToolsExternalVisualStudioDir Condition=" '$(ToolsExternalVisualStudioDir)' == '' AND Exists('C:\Program Files (x86)\Microsoft Visual Studio 12.0')">C:\Program Files (x86)\Microsoft Visual Studio 12.0</ToolsExternalVisualStudioDir>
         <ToolsExternalVisualStudioDir Condition=" '$(ToolsExternalVisualStudioDir)' == '' AND Exists('C:\Program Files (x86)\Microsoft Visual Studio 11.0')">C:\Program Files (x86)\Microsoft Visual Studio 11.0</ToolsExternalVisualStudioDir>


### PR DESCRIPTION
Allow for vs2017 professional uses to execute unit tests.
nBuildKit will now find the vstest path in the professional folder.